### PR TITLE
Fix "failed setting rlimit: invalid argument" on osx

### DIFF
--- a/autofdmax/init_linux.go
+++ b/autofdmax/init_linux.go
@@ -1,4 +1,5 @@
 // +build linux
+
 package autofdmax
 
 import (

--- a/fdmax.go
+++ b/fdmax.go
@@ -1,6 +1,7 @@
 package fdmax
 
 import (
+	"runtime"
 	"syscall"
 )
 
@@ -26,6 +27,12 @@ func Get() (*Limits, error) {
 func Set(maxLimit uint64) error {
 	var rLimit syscall.Rlimit
 	rLimit.Max = maxLimit
-	rLimit.Cur = maxLimit
+
+	if runtime.GOOS == "darwin" && rLimit.Cur > 24576 {
+		rLimit.Cur = 24576
+	} else {
+		rLimit.Cur = maxLimit
+	}
+
 	return syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 }


### PR DESCRIPTION
https://github.com/golang/go/issues/30401

We fix this by setting the value to the somewhat magic 24576 when on osx (darwin).